### PR TITLE
fixed non-portable include directive

### DIFF
--- a/STM32 FW Project/BLE Remocon Beta release 301117/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
+++ b/STM32 FW Project/BLE Remocon Beta release 301117/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
@@ -59,7 +59,7 @@
   */ 
 
 /* Includes ------------------------------------------------------------------*/
-#include "USBD_CDC.h"
+#include "usbd_cdc.h"
 #include "usbd_desc.h"
 #include "usbd_ctlreq.h"
 


### PR DESCRIPTION
I fixed a non-portable #include. I had tried compiling the TrueStudio project on Linux in v9.0 and the #include was the only error.